### PR TITLE
Fix builddocfile.py to properly assign class to enum Parent

### DIFF
--- a/scripts/builddocfile.py
+++ b/scripts/builddocfile.py
@@ -143,6 +143,8 @@ def _write_enum(name: str, enum_dict: dict, writer: TextIO, depth: int = 0):
             is_parent = True
     if not is_parent:
         print(DEPTH_SEP * depth + f"---@enum {name}", file=writer)
+    else:
+        print(DEPTH_SEP * depth + f"---@class {name}", file=writer)
     print(DEPTH_SEP * depth + f"{name} = ""{", file=writer)
     for (key, item) in enum_dict.items():
         if is_parent:

--- a/src/docs/repentogon_new/rendering/Renderer.lua
+++ b/src/docs/repentogon_new/rendering/Renderer.lua
@@ -7,6 +7,9 @@ Renderer.VertexAttributeFormat = {}
 ---@type ShaderType
 Renderer.ShaderType = {}
 
+---@type GLSLType
+Renderer.GLSLType = {}
+
 ---@param filePath string @The path to the image.
 ---@return Image
 function Renderer.LoadImage(filePath)

--- a/src/isaacGlobals.ts
+++ b/src/isaacGlobals.ts
@@ -210,6 +210,7 @@ const REPENTOGON_GLOBALS = [
     "ProceduralItemManager",
     "ProjectileMode",
     "PurityState",
+    "Renderer",
     "RetractingSpikesVariant",
     "RoomConfigHolder",
     "RoomSubType",


### PR DESCRIPTION
Additionally add GLSLType to Renderer definition.

Change didn't add any redundant @class notations to the api file in my testing.
This solution fixes the current issue of enums accessed via the Renderer class not being treated as enums.
Will also fix future issues of this type that could appear with RGON updates.